### PR TITLE
Fix error where typ and from could have the same value

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -214,7 +214,9 @@
 				if (!ranges[typ][typ]) { // no alpha|HEX
 					if (type !== typ && typ !== 'XYZ') {
 						from = exceptions[typ] || 'rgb';
-						colors[typ] = convert[from + '2' + typ](colors[from]);
+						if (typ !== from) {
+							colors[typ] = convert[from + '2' + typ](colors[from]);
+						}
 					}
 
 					if (!RND[typ]) RND[typ] = {};


### PR DESCRIPTION
When I am dynamically creating input fields that use the colorpicker, then I get an error that undefined is not a function. This is because from and typ have the same value.