### PR TITLE
Update jsColor.js

### DIFF
--- a/javascript_implementation/jsColor.js
+++ b/javascript_implementation/jsColor.js
@@ -98,7 +98,8 @@
 				var onOff = off ? 'removeEventListener' : 'addEventListener',
 					focusListener = function(e) {
 						var input = this,
-							position = {left: input.offsetLeft, top: input.offsetTop},
+							inputRect = input.getBoundingClientRect(),
+							position = {left: inputRect.left, top: inputRect.top},
 							index = multiple ? Array.prototype.indexOf.call(elms, this) : 0,
 							colorPicker = colorPickers[index] ||
 								(colorPickers[index] = createInstance(this, config)),


### PR DESCRIPTION
Hi, I encountered an issue where the offset position was incorrectly calculated, resulting in a misplaced color picker on focus.

-Use getBoundingClientRect instead of element offset to account for absolute positioned input elements.

