### PR TITLE
fix for pages with clickable SVG elements

### DIFF
--- a/javascript_implementation/jsColor.js
+++ b/javascript_implementation/jsColor.js
@@ -135,7 +135,7 @@
 							colorPickerUI = (colorPicker ? colorPicker.nodes.colorPicker : undefined),
 							animationSpeed = colorPicker ? colorPicker.color.options.animationSpeed : 0,
 							isColorPicker = colorPicker && (function(elm) {
-								while (elm) {
+								while (elm && elm instanceof HTMLElement) {
 									if ((elm.className || '').indexOf('cp-app') !== -1) return elm;
 									elm = elm.parentNode;
 								}


### PR DESCRIPTION
thanks for the nice color picking widget.

I found and fixed a problem with pages that have SVG elements that receive mouse events.

a test case for this is available at: https://gist.github.com/danielcwilliams/1b17956ee9d4e27358f521b3e29c75a0