### PR TITLE
Fix markdown section headers

### DIFF
--- a/jQuery_implementation/README.md
+++ b/jQuery_implementation/README.md
@@ -3,10 +3,10 @@
 
 Some description follows soon...
 
-##Demo
+## Demo
 See **demo** at [dematte.at/cpn/jQuery_implementation](http://dematte.at/cpn/jQuery_implementation)
 
-##Usage
+## Usage
 
 ```javascript
     $('input.color').colorPicker();

--- a/javascript_implementation/README.md
+++ b/javascript_implementation/README.md
@@ -3,10 +3,10 @@
 
 Some description follows soon...
 
-##Demo
+## Demo
 See **demo** at [dematte.at/cpn/javaScript_implementation](http://dematte.at/cpn/javaScript_implementation)
 
-##Usage
+## Usage
 
 ```javascript
     jsColorPicker('input.color');


### PR DESCRIPTION
Github's markdown parser requires that `##` section headers have whitespace immediately after them for them to be recognized and get larger bold text .